### PR TITLE
Allow consumers to implement fallback mechanisms on success or failure

### DIFF
--- a/lua/open-link/open.lua
+++ b/lua/open-link/open.lua
@@ -41,7 +41,7 @@ local function open(link)
 
   if vim.regex("^\\s*$"):match_str(link) then
     vim.notify("No link was found at the cursor.", vim.log.levels.WARN)
-    return
+    return false
   end
 
   link = expand(link)


### PR DESCRIPTION
Allows consumers to implement fallback mechanisms using the return value or a success/failure callback function like this:

```lua
local open_link = require('open-link.open')

local web_browser = function(opts)
  opts = opts or {}

  local opened = open_link(opts.url)

  if opened == false and opts.fallback_url then
    open_link(opts.fallback_url)
  end
end

/* or this */

local web_browser = function(opts)
  opts = opts or {}

  open_link(opts.url, {
    success_callback = function()
      vim.notify('Link opened.')
    end,
    failure_callback = function()
      if opts.fallback_url then
        open_link(opts.fallback_url)
      end
    end
  })
end
```