### PR TITLE
Add support for additional link prefixes

### DIFF
--- a/lua/open-link/config.lua
+++ b/lua/open-link/config.lua
@@ -2,10 +2,12 @@
 
 ---@class OpenLinkConfig
 ---@field expanders LinkExpander[]
+---@field extraLinkPrefixes string[]
 
 ---@type OpenLinkConfig
 local config = {
   expanders = {},
+  extraLinkPrefixes = {},
 }
 
 return config

--- a/lua/open-link/helpers.lua
+++ b/lua/open-link/helpers.lua
@@ -1,3 +1,5 @@
+local config = require("open-link.config")
+
 ---@param filepath string
 ---@return boolean
 local function fileExists(filepath)
@@ -37,7 +39,13 @@ local function findAbsPath(link)
   end
 end
 
+---@param link string
 local function isHttpOrFileLink(link)
+  for _, prefix in ipairs(config.extraLinkPrefixes) do
+    if vim.startswith(link, prefix) then
+      return true
+    end
+  end
   return vim.startswith(link, "http://")
     or vim.startswith(link, "https://")
     or vim.startswith(link, "file://")

--- a/lua/open-link/init.lua
+++ b/lua/open-link/init.lua
@@ -6,6 +6,7 @@ local extendVimUiOpen = require("open-link.extend-vim-ui-open")
 ---@class SetupOptions
 ---@field expanders? LinkExpander[] Replaces all of the expanders
 ---@field extendVimUiOpen? boolean Wrap vim.ui.open (default = true)
+---@field extraLinkPrefixes? string[] Additional prefixes to be considered links (default = {})
 
 ---@param opts SetupOptions
 local function setup(opts)
@@ -15,6 +16,10 @@ local function setup(opts)
 
   if opts.extendVimUiOpen ~= false then
     extendVimUiOpen()
+  end
+
+  if opts.extraLinkPrefixes ~= nil then
+    vim.list_extend(config.extraLinkPrefixes, opts.extraLinkPrefixes)
   end
 
   vim.api.nvim_create_user_command("OpenLink", function()


### PR DESCRIPTION
By default only `http://` and `https://` and `file://` are recognized as openable links.

This change allows a replacement expander to link directly into an app url scheme, and still be recognized as a link.

Eg.

```
            require("open-link").setup({
                expanders = {
                    -- expands "{user}/{repo}" to the github repo URL
                    expanders.github,

                    -- expands "format-on-save#15" the issue/pr #15 in the specified github project
                    -- ("format-on-save" is the shortcut/keyword)
                    expanders.github_issue_or_pr("format-on-save", "elentok/format-on-save.nvim"),

                    expanders.regex("^https://app.clickup.com", "clickup://"),
                },
                extraLinkPrefixes = { "clickup://" },
            })

```